### PR TITLE
Fix interface of uncontrolled

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,17 @@ render(
 **Uncontrolled** is a generic interface however, and allows you to modify all kind of properties to behave in this way (**TODO**: which)
 
 ```javascript
+import {uncontrolled} from '@klarna/higher-order-components'
 
+uncontrolled({
+  prop: 'value',
+  defaultProp: 'defaultValue',
+  handlers: {
+    onChange: ({value: currentValue}) => (e) => e.target.value,
+    onClear: () => () => '',
+    onDoubleClick: ({value: currentValue}) => () => `${currentValue}${currentValue}`
+  }
+})(Input)
 ```
 
 ## Deprecated decorator

--- a/src/namespacedDisplayName.spec.js
+++ b/src/namespacedDisplayName.spec.js
@@ -6,6 +6,10 @@ describe('namespacedDisplayName', () => {
     const Component = function () {}
     const namespace = 'foo'
     const name = 'bar'
-    equal(namespacedDisplayName(namespace)(name)(Component).displayName, `${namespace}.${name}`)
+
+    equal(
+      namespacedDisplayName(namespace)(name)(Component).displayName,
+      `${namespace}.${name}`
+    )
   })
 })

--- a/src/themeable.spec.js
+++ b/src/themeable.spec.js
@@ -4,11 +4,12 @@ import {getContextualizer} from 'react-context-props'
 import {equal} from 'assert'
 import themeable from './themeable'
 
-const root = document.createElement('div')
-document.body.appendChild(root)
-
 describe('themeable', () => {
   it('gets the prop from context', () => {
+    const root = document.createElement('div')
+    document.body.innerHTML = ''
+    document.body.appendChild(root)
+
     const Theme = getContextualizer({
       customizations: PropTypes.shape({
         informal: PropTypes.bool

--- a/src/uncontrolled.spec.js
+++ b/src/uncontrolled.spec.js
@@ -1,0 +1,200 @@
+import React from 'react'
+import {render} from 'react-dom'
+import {equal} from 'assert'
+import uncontrolled from './uncontrolled'
+
+describe('uncontrolled', () => {
+  it('makes the prop uncontrolled when undefined', done => {
+    const root = document.createElement('div')
+    document.body.innerHTML = ''
+    document.body.appendChild(root)
+
+    function ButtonSwitch1 ({ pressed, onClick }) {
+      return <div>
+        <button onClick={onClick}>press</button>
+        <span>{pressed ? 'pressed' : 'not pressed'}</span>
+      </div>
+    }
+
+    const UncontrolledButtonSwitch = uncontrolled({
+      prop: 'pressed',
+      defaultProp: 'autoPressed',
+      handlers: {
+        onClick: () => () => true
+      }
+    })(ButtonSwitch1)
+
+    render(
+      <UncontrolledButtonSwitch />,
+      root
+    )
+
+    root.querySelector('button').click()
+
+    setTimeout(() => {
+      expect(root.querySelector('span').textContent).toBe('pressed')
+      done()
+    })
+  })
+
+  it('makes the prop controlled with defined', () => {
+    const root = document.createElement('div')
+    document.body.innerHTML = ''
+    document.body.appendChild(root)
+
+    function ButtonSwitch ({ pressed, onClick }) {
+      return <div>
+        <button onClick={onClick}>press</button>
+        <span>{pressed ? 'pressed' : 'not pressed'}</span>
+      </div>
+    }
+
+    const UncontrolledButtonSwitch = uncontrolled({
+      prop: 'pressed',
+      defaultProp: 'autoPressed',
+      handlers: {
+        onClick: () => () => true
+      }
+    })(ButtonSwitch)
+
+    render(
+      <UncontrolledButtonSwitch pressed={false} />,
+      root
+    )
+
+    root.querySelector('button').click()
+
+    equal(root.querySelector('span').textContent, 'not pressed')
+  })
+
+  it('makes the prop uncontrolled with default value when default prop is provided', () => {
+    const root = document.createElement('div')
+    document.body.innerHTML = ''
+    document.body.appendChild(root)
+
+    function ButtonSwitch ({ pressed, onClick }) {
+      return <div>
+        <button onClick={onClick}>press</button>
+        <span>{pressed ? 'pressed' : 'not pressed'}</span>
+      </div>
+    }
+
+    const UncontrolledButtonSwitch = uncontrolled({
+      prop: 'pressed',
+      defaultProp: 'autoPressed',
+      handlers: {
+        onClick: () => () => true
+      }
+    })(ButtonSwitch)
+
+    render(
+      <UncontrolledButtonSwitch autoPressed={false} />,
+      root
+    )
+
+    root.querySelector('button').click()
+
+    equal(root.querySelector('span').textContent, 'pressed')
+  })
+
+  it('uses the defaultProp to set the initial value', () => {
+    const root = document.createElement('div')
+    document.body.innerHTML = ''
+    document.body.appendChild(root)
+
+    function ButtonSwitch ({ pressed, onClick }) {
+      return <div>
+        <button onClick={onClick}>press</button>
+        <span>{pressed ? 'pressed' : 'not pressed'}</span>
+      </div>
+    }
+
+    const UncontrolledButtonSwitch = uncontrolled({
+      prop: 'pressed',
+      defaultProp: 'autoPressed',
+      handlers: {
+        onClick: () => () => true
+      }
+    })(ButtonSwitch)
+
+    render(
+      <UncontrolledButtonSwitch autoPressed />,
+      root
+    )
+
+    equal(root.querySelector('span').textContent, 'pressed')
+  })
+
+  describe('using the old props', () => {
+    it('updates the value when uncontrolled', () => {
+      const root = document.createElement('div')
+      document.body.innerHTML = ''
+      document.body.appendChild(root)
+
+      function ButtonSwitch ({ pressed, onClick }) {
+        return <div>
+          <button onClick={onClick}>toggle</button>
+          <span>{pressed ? 'pressed' : 'not pressed'}</span>
+        </div>
+      }
+
+      const UncontrolledButtonSwitch = uncontrolled({
+        prop: 'pressed',
+        defaultProp: 'autoPressed',
+        handlers: {
+          onClick: ({pressed}) => () => !pressed
+        }
+      })(ButtonSwitch)
+
+      render(
+        <UncontrolledButtonSwitch />,
+        root
+      )
+
+      root.querySelector('button').click()
+
+      equal(root.querySelector('span').textContent, 'pressed')
+
+      root.querySelector('button').click()
+
+      equal(root.querySelector('span').textContent, 'not pressed')
+    })
+  })
+
+  describe('using the original event data', () => {
+    it('makes the prop uncontrolled when undefined', () => {
+      const root = document.createElement('div')
+      document.body.innerHTML = ''
+      document.body.appendChild(root)
+
+      function ButtonSwitch ({ pressed, onClick }) {
+        return <div>
+          <button id='press' onClick={() => onClick(true)}>press</button>
+          <button id='unpress' onClick={() => onClick(false)}>unpress</button>
+          <span>{pressed ? 'pressed' : 'not pressed'}</span>
+        </div>
+      }
+
+      const UncontrolledButtonSwitch = uncontrolled({
+        prop: 'pressed',
+        defaultProp: 'autoPressed',
+        handlers: {
+          onClick: () => (pressed) => pressed
+        }
+      })(ButtonSwitch)
+
+      render(
+        <UncontrolledButtonSwitch />,
+        root
+      )
+
+      root.querySelector('#press').click()
+
+      equal(root.querySelector('span').textContent, 'pressed')
+
+      root.querySelector('#unpress').click()
+
+      equal(root.querySelector('span').textContent, 'not pressed')
+    })
+  })
+})


### PR DESCRIPTION
This is motivated by the discussion on https://github.com/klarna/ui/pull/121#pullrequestreview-18855061

The new API for the uncontrolled would be:

```javascript
uncontrolled({
  prop: 'value',
  defaultProp: 'defaultValue',
  handlers: {
    onChange: ({value: currentValue}) => (e) => e.target.value,
    onClear: () => () => '',
    onDoubleClick: ({value: currentValue}) => () => `${currentValue}${currentValue}`
  }
})(Input)
```

- [x] Documentation