### PR TITLE
Update overridable styles when receiving new props

### DIFF
--- a/src/overridable.js
+++ b/src/overridable.js
@@ -11,12 +11,22 @@ export default (styles = {}, designName) => (Target) => {
     }
 
     componentWillMount () {
-      this.styles = {...styles, ...this.props.styles}
+      this.mergeStylesProp(this.props.styles)
       this.getAndSetOverride()
+    }
+
+    componentWillReceiveProps ({ styles }) {
+      if (styles && Object.keys(styles).length > 0) {
+        this.mergeStylesProp(styles)
+      }
     }
 
     componentWillUpdate () {
       this.getAndSetOverride()
+    }
+
+    mergeStylesProp (stylesProp) {
+      this.styles = {...styles, ...stylesProp}
     }
 
     getAndSetOverride () {


### PR DESCRIPTION
The Overridable HOC is not keeping the styles prop up to date when a client sets it after the wrapped component is mounted. This patch fixes the issue.