### PR TITLE
Properly publish the `dist` files to npm 🥁

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-.babelrc
-.editorconfig
-.eslintignore
-.eslintrc
-coverage
-node_modules
-npm-debug.log
-src
-.sagui

--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "test:unit": "sagui test:unit --coverage",
     "test:unit:watch": "sagui test:unit --watch"
   },
+  "files": [
+    "dist"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/klarna/higher-order-components.git"


### PR DESCRIPTION
The dist folder is currently not being published:

![screen shot 2017-08-02 at 10 22 27](https://user-images.githubusercontent.com/6001/28864337-84bb7686-776c-11e7-821c-784da7e315df.png)

This PR fixes it, and also stops publishing not needed stuff.

You can verify it packages the correct files by running `npm pack` and inspect the generated tgz.