### PR TITLE
Fix publishing of assets to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "sagui build",
     "dist": "sagui dist",
     "format": "sagui format",
-    "prepublishOnly": "babel src/ -d dist/ --ignore spec.js,example/",
+    "prepare": "babel src/ -d dist/ --ignore spec.js,example/",
     "start": "sagui develop --port 3000",
     "test": "sagui test",
     "test:lint": "sagui test:lint",


### PR DESCRIPTION
The `prepublishOnly` lifecycle is just so confusing. It doesn’t do at all what you would expect, but instead:

“...prepubishOnly is not meant to be used for build steps. This lifecycle runs after tarball creation, right before we do the final upload. If you want to have a build step, please use prepare instead, as of npm@4.” (https://github.com/npm/npm/issues/15147#issuecomment-265956052)


Here is an issue and discussion about how it makes no sense: https://github.com/npm/npm/issues/15147#issuecomment-288597553

Currently our package has no published assets because of this. Glorious!