### PR TITLE
PureComponent -> Component

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,14 +37,14 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",
     "jwt-simple": "^0.5.1",
-    "prettier": "^1.3.1",
+    "prettier": "^1.5.3",
     "prop-types": "^15.5.10",
     "react": "^15.5.0",
     "react-component-queries": "^2.1.1",
     "react-context-props": "^2.2.0",
     "react-dom": "^15.5.0",
     "react-sizeme": "^2.3.2",
-    "sagui": "^11.0.2"
+    "sagui": "^11.1.0"
   },
   "peerDependencies": {
     "prop-types": "^15.5.10",

--- a/src/withAutofillProps.spec.js
+++ b/src/withAutofillProps.spec.js
@@ -21,7 +21,11 @@ describe('withAutofillProps', () => {
     function Target({ autofilled, onAnimationStart }) {
       animationStartCallback = onAnimationStart
 
-      return <div>{autofilled ? 'autofilled' : 'not autofilled'}</div>
+      return (
+        <div>
+          {autofilled ? 'autofilled' : 'not autofilled'}
+        </div>
+      )
     }
 
     const DecoratedTarget = withAutofillProps({
@@ -44,7 +48,11 @@ describe('withAutofillProps', () => {
     function Target({ autofilled, onAnimationStart }) {
       animationStartCallback = onAnimationStart
 
-      return <div>{autofilled ? 'autofilled' : 'not autofilled'}</div>
+      return (
+        <div>
+          {autofilled ? 'autofilled' : 'not autofilled'}
+        </div>
+      )
     }
 
     const DecoratedTarget = withAutofillProps({

--- a/src/withUncontrolledProp.js
+++ b/src/withUncontrolledProp.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import React, { Component } from 'react'
 import wrapDisplayName from 'recompose/wrapDisplayName'
 
 const makeWithUncontrolledPropHandler = ({
@@ -23,7 +23,7 @@ const makeWithUncontrolledPropHandler = ({
 }
 
 export default ({ defaultProp, handlers, prop, resetHandlerName }) => Target => {
-  class WithUncontrolledProp extends PureComponent {
+  class WithUncontrolledProp extends Component {
     componentDidMount() {
       this.setState({
         [prop]: this.props[prop] != null ? this.props[prop] : this.props[defaultProp],

--- a/src/withUniqueFormIdentifier.js
+++ b/src/withUniqueFormIdentifier.js
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react'
+import React, { Component } from 'react'
 import wrapDisplayName from 'recompose/wrapDisplayName'
 import seededRandom from 'seed-random'
 
@@ -16,7 +16,7 @@ const uuid = seed => {
 
 let counter = 0
 export default Target => {
-  class WithUniqueFormIdentifier extends PureComponent {
+  class WithUniqueFormIdentifier extends Component {
     constructor() {
       super()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1227,6 +1227,10 @@ caniuse-lite@^1.0.30000697, caniuse-lite@^1.0.30000704:
   version "1.0.30000709"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000709.tgz#e027c7a0dfd5ada58f931a1080fc71965375559b"
 
+case-sensitive-paths-webpack-plugin@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.1.tgz#3d29ced8c1f124bf6f53846fb3f5894731fdc909"
+
 caseless@~0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.11.0.tgz#715b96ea9841593cc33067923f5ec60ebda4f7d7"
@@ -3391,7 +3395,7 @@ invert-kv@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/invert-kv/-/invert-kv-1.0.0.tgz#104a8e4aaca6d3d8cd157a8ef8bfab2d7a3ffdb6"
 
-ip@^1.1.0:
+ip@^1.1.0, ip@^1.1.5:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
 
@@ -5116,7 +5120,7 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@^1.3.1:
+prettier@^1.3.1, prettier@^1.5.3:
   version "1.5.3"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.5.3.tgz#59dadc683345ec6b88f88b94ed4ae7e1da394bfe"
 
@@ -5694,9 +5698,9 @@ safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.1.0, s
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
 
-sagui@^11.0.2:
-  version "11.0.2"
-  resolved "https://registry.yarnpkg.com/sagui/-/sagui-11.0.2.tgz#54ad254028617542023251e2635a1205dada1f32"
+sagui@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.yarnpkg.com/sagui/-/sagui-11.1.0.tgz#bb8eefaf36834035e5189b3d4cfde1e4610652c1"
   dependencies:
     ajv "^5.2.2"
     autoprefixer "^7.1.2"
@@ -5711,6 +5715,7 @@ sagui@^11.0.2:
     babel-preset-flow "^6.23.0"
     babel-preset-react "^6.24.1"
     babel-preset-stage-3 "^6.24.1"
+    case-sensitive-paths-webpack-plugin "^2.1.1"
     chalk "^2.0.1"
     clean-webpack-plugin "^0.1.16"
     commander "^2.9.0"
@@ -5733,6 +5738,7 @@ sagui@^11.0.2:
     happypack "^3.0.3"
     html-loader "^0.4.5"
     html-webpack-plugin "^2.28.0"
+    ip "^1.1.5"
     jasmine-core "^2.5.2"
     karma "^1.6.0"
     karma-chrome-launcher "^2.2.0"


### PR DESCRIPTION
PureComponent was messing with the rerendering of the tree when context was updated. We need the ability to update context for themeing. This PR removes `PureComponent` which was an unnecessary optimization.