### PR TITLE
Fix `withHoverProps` using `onMouseEnter` and `onMouseLeave`

### DIFF
--- a/src/withHoverProps.js
+++ b/src/withHoverProps.js
@@ -9,23 +9,23 @@ export default hoverProps => Target => {
       this.state = {
         hovered: false,
       }
-      this.onMouseOver = this.onMouseOver.bind(this)
-      this.onMouseOut = this.onMouseOut.bind(this)
+      this.onMouseEnter = this.onMouseEnter.bind(this)
+      this.onMouseLeave = this.onMouseLeave.bind(this)
     }
 
-    onMouseOver(...args) {
+    onMouseEnter(...args) {
       this.setState({ hovered: true })
 
-      if (this.props.onMouseOver) {
-        this.props.onMouseOver(...args)
+      if (this.props.onMouseEnter) {
+        this.props.onMouseEnter(...args)
       }
     }
 
-    onMouseOut(...args) {
+    onMouseLeave(...args) {
       this.setState({ hovered: false })
 
-      if (this.props.onMouseOut) {
-        this.props.onMouseOut(...args)
+      if (this.props.onMouseLeave) {
+        this.props.onMouseLeave(...args)
       }
     }
 
@@ -33,8 +33,8 @@ export default hoverProps => Target => {
       return (
         <Target
           {...this.props}
-          onMouseOver={this.onMouseOver}
-          onMouseOut={this.onMouseOut}
+          onMouseEnter={this.onMouseEnter}
+          onMouseLeave={this.onMouseLeave}
           {...this.state.hovered && hoverProps}
         />
       )

--- a/src/withHoverProps.spec.js
+++ b/src/withHoverProps.spec.js
@@ -26,7 +26,7 @@ describe('withHoverProps', () => {
       componentDidMount() {
         setTimeout(() => {
           this.updated = true
-          this.props.onMouseOver()
+          this.props.onMouseEnter()
         })
       }
 
@@ -63,12 +63,12 @@ describe('withHoverProps', () => {
     const root = document.createElement('div')
     class Target extends Component {
       componentDidMount() {
-        this.props.onMouseOver()
+        this.props.onMouseEnter()
       }
 
       componentDidUpdate() {
         setTimeout(() => {
-          this.props.onMouseOut()
+          this.props.onMouseLeave()
           setTimeout(() => {
             equal(root.querySelector('span').textContent, '')
             done()


### PR DESCRIPTION
Because `onMouseOver` and `onMouseOut` bubbles up to the DOM triggering unnecessary re-renders every time you hover on any children of wrapped with this HOC component. `onMouseEnter` and `onMouseLeave` stops this madness and works just like "hover".

See https://api.jquery.com/mouseenter/ and https://api.jquery.com/mouseleave/ for further details.

This is a breaking change because we need to change props mapping in every wrapped component (if it's not in `{...props}` ofc).